### PR TITLE
Add CI+releaser

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+### Proposed Changes
+
+### Checklist
+
+- [ ] I have included `#major/#minor/#patch` tags in commit messages for commits that make major, minor or patch changes, so the [autoreleaser](https://github.com/anothrNick/github-tag-action#bumping) can appropriately bump the package version
+
+### Testing Instructions
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,28 @@
+name: Quality Gate
+env:
+  COVERAGE_THRESH_PCT: 0
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+jobs:
+  ci_gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+      - name: Setup unit test
+        run: go install github.com/klmitch/overcover@v1.2.1
+      - name: Build check
+        run: go build
+      - name: Run unit test with coverage
+        run: go test --coverprofile cover.out ./...
+      - name: Check coverage meets threshold
+        run: overcover --coverprofile cover.out ./... --threshold ${{ env.COVERAGE_THRESH_PCT }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
-          DEFAULT_BUMP: minor
+          DEFAULT_BUMP: patch
       - name: Publish doc to go.dev packages
         run: |
           git pull

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,35 @@
+name: Tag + Godoc Publish On Main Push
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+          contents: write
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - uses: actions/checkout@v3
+      - name: Bump version and push tag
+        id: tag-rel
+        uses: anothrNick/github-tag-action@1.39.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+          DEFAULT_BUMP: minor
+      - name: Publish doc to go.dev packages
+        run: |
+          git pull
+          export latest="$(git describe --tags `git rev-list --tags --max-count=1`)"
+          curl https://proxy.golang.org/github.com/virtru/oteltracer/@v/$latest.info
+      - uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag-rel.outputs.new_tag }}
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          generateReleaseNotes: true
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a simple CI check, as well as an autotagger/autoreleaser that fires on PR merge.

This should automate simple changes